### PR TITLE
chore: bump rust toolchain from 1.38.0 to 1.41.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@ Environment for building [ckb](https://github.com/nervosnetwork/ckb#readme).
 
 ## How to Upgrade Rust
 
-- Upgrade rustup if needed in all Dockerfiles
-- Update rust version in all Dockerfiles
-- Commit and tag `rust-${VERSION}` such as `rust-1.38.0`
+- Update rustup version if needed in [`gen-dockerfiles`].
+- Update rust version in [`gen-dockerfiles`].
+- Run the script [`gen-dockerfiles`].
+- Commit and tag `rust-${RUST_VERSION}` such as `rust-1.38.0`.
+
+[`gen-dockerfiles`]: gen-dockerfiles

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -16,8 +16,8 @@ RUN set -eux; \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUSTUP_VERSION=1.19.0 \
-    RUSTUP_SHA256=36285482ae5c255f2decfab27d32ba19465804cb3ddf5a23e6ff2a7b0f6e0250 \
+    RUSTUP_VERSION=1.21.1 \
+    RUSTUP_SHA256=ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b \
     RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
@@ -26,7 +26,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.38.0
+ENV RUST_VERSION=1.41.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -11,8 +11,8 @@ RUN set -eux; \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUSTUP_VERSION=1.19.0 \
-    RUSTUP_SHA256=36285482ae5c255f2decfab27d32ba19465804cb3ddf5a23e6ff2a7b0f6e0250 \
+    RUSTUP_VERSION=1.21.1 \
+    RUSTUP_SHA256=ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b \
     RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
@@ -21,7 +21,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.38.0
+ENV RUST_VERSION=1.41.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/gen-dockerfiles
+++ b/gen-dockerfiles
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import os
+from urllib import request
+
+RUST_VERSION = '1.38.0'
+RUSTUP_VERSION = '1.19.0'
+
+RUST_ARCH = 'x86_64-unknown-linux-gnu'
+
+DISTRIBUTIONS = [
+    # Ubuntu
+    'xenial', 'bionic',
+    # CentOS
+    'centos-7',
+]
+
+
+def fetch_rustup_hash():
+    url = f'https://static.rust-lang.org/rustup/archive/{RUSTUP_VERSION}/{RUST_ARCH}/rustup-init.sha256'
+    with request.urlopen(url) as f:
+        return f.read().decode('utf-8').split()[0]
+
+
+def load_template(dist):
+    with open(f'templates/{dist}.Dockerfile', 'r') as f:
+        return f.read()
+
+def save_dockerfile(dist, contents):
+    filepath = f'{dist}/Dockerfile'
+    filedir = os.path.dirname(filepath)
+    if filedir and not os.path.exists(filedir):
+        os.makedirs(filedir)
+    with open(filepath, 'w') as f:
+        f.write(contents)
+
+
+def generate_dockerfile(dist, rustup_sha256):
+    template = load_template(dist)
+    rendered = template \
+        .replace('%%RUST_VERSION%%', RUST_VERSION) \
+        .replace('%%RUSTUP_VERSION%%', RUSTUP_VERSION) \
+        .replace('%%RUSTUP_SHA256%%', rustup_sha256) \
+        .replace('%%RUST_ARCH%%', RUST_ARCH)
+    save_dockerfile(dist, rendered)
+
+
+def main():
+    rustup_sha256 = fetch_rustup_hash()
+    for dist in DISTRIBUTIONS:
+        generate_dockerfile(dist, rustup_sha256)
+
+
+if __name__ == '__main__':
+    main()

--- a/gen-dockerfiles
+++ b/gen-dockerfiles
@@ -3,8 +3,8 @@
 import os
 from urllib import request
 
-RUST_VERSION = '1.38.0'
-RUSTUP_VERSION = '1.19.0'
+RUST_VERSION = '1.41.0'
+RUSTUP_VERSION = '1.21.1'
 
 RUST_ARCH = 'x86_64-unknown-linux-gnu'
 

--- a/templates/bionic.Dockerfile
+++ b/templates/bionic.Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:bionic
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        libssl-dev \
+        git \
+        pkg-config \
+        libclang-dev clang; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUSTUP_VERSION=%%RUSTUP_VERSION%% \
+    RUSTUP_SHA256=%%RUSTUP_SHA256%% \
+    RUST_ARCH=%%RUST_ARCH%%
+
+RUN set -eux; \
+    url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
+    wget "$url"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init
+
+ENV RUST_VERSION=%%RUST_VERSION%%
+
+RUN set -eux; \
+    ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    openssl version;

--- a/templates/centos-7.Dockerfile
+++ b/templates/centos-7.Dockerfile
@@ -1,0 +1,32 @@
+FROM centos:7
+
+ENV PATH=/root/.cargo/bin:$PATH
+
+RUN set -eux; \
+    yum install -y centos-release-scl; \
+    yum install -y git curl make gcc-c++ openssl-devel llvm-toolset-7; \
+    yum clean all; \
+    rm -rf /var/cache/yum
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUSTUP_VERSION=%%RUSTUP_VERSION%% \
+    RUSTUP_SHA256=%%RUSTUP_SHA256%% \
+    RUST_ARCH=%%RUST_ARCH%%
+
+RUN set -eux; \
+    url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
+    curl -LO "$url"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init
+
+ENV RUST_VERSION=%%RUST_VERSION%%
+
+RUN set -eux; \
+    ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version;

--- a/templates/xenial.Dockerfile
+++ b/templates/xenial.Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:xenial
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        git \
+        pkg-config \
+        libclang-dev clang; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV OPENSSL_VERSION=1.1.1c \
+    OPENSSL_SHA256=f6fb3079ad15076154eda9413fed42877d668e7069d9b87396d0804fdb3f4c90
+
+RUN set -eux; \
+    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
+    wget "$url"; \
+    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
+    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
+    cd openssl-${OPENSSL_VERSION}; \
+    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
+    make; \
+    make install; \
+    cd ..; \
+    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
+
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUSTUP_VERSION=%%RUSTUP_VERSION%% \
+    RUSTUP_SHA256=%%RUSTUP_SHA256%% \
+    RUST_ARCH=%%RUST_ARCH%%
+
+RUN set -eux; \
+    url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
+    wget "$url"; \
+    echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init
+
+ENV RUST_VERSION=%%RUST_VERSION%%
+
+RUN set -eux; \
+    ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    openssl version;

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUSTUP_VERSION=1.19.0 \
-    RUSTUP_SHA256=36285482ae5c255f2decfab27d32ba19465804cb3ddf5a23e6ff2a7b0f6e0250 \
+    RUSTUP_VERSION=1.21.1 \
+    RUSTUP_SHA256=ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b \
     RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
@@ -40,7 +40,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.38.0
+ENV RUST_VERSION=1.41.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \


### PR DESCRIPTION
- feat: add templates to generate Dockerfiles
  So, we don't have to query the rustup sha256 checksum and update all versions and checksums in all Dockerfiles manually.
- chore: bump rust toolchain from 1.38.0 to 1.41.0