### PR TITLE
chore: bump rust toolchain from 1.41.0 to 1.45.0

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -16,8 +16,8 @@ RUN set -eux; \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUSTUP_VERSION=1.21.1 \
-    RUSTUP_SHA256=ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b \
+    RUSTUP_VERSION=1.22.1 \
+    RUSTUP_SHA256=49c96f3f74be82f4752b8bffcf81961dea5e6e94ce1ccba94435f12e871c3bdb \
     RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
@@ -26,7 +26,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.41.0
+ENV RUST_VERSION=1.45.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -11,8 +11,8 @@ RUN set -eux; \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUSTUP_VERSION=1.21.1 \
-    RUSTUP_SHA256=ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b \
+    RUSTUP_VERSION=1.22.1 \
+    RUSTUP_SHA256=49c96f3f74be82f4752b8bffcf81961dea5e6e94ce1ccba94435f12e871c3bdb \
     RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
@@ -21,7 +21,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.41.0
+ENV RUST_VERSION=1.45.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/gen-dockerfiles
+++ b/gen-dockerfiles
@@ -3,8 +3,8 @@
 import os
 from urllib import request
 
-RUST_VERSION = '1.41.0'
-RUSTUP_VERSION = '1.21.1'
+RUST_VERSION = '1.45.0'
+RUSTUP_VERSION = '1.22.1'
 
 RUST_ARCH = 'x86_64-unknown-linux-gnu'
 

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -30,8 +30,8 @@ RUN set -eux; \
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUSTUP_VERSION=1.21.1 \
-    RUSTUP_SHA256=ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b \
+    RUSTUP_VERSION=1.22.1 \
+    RUSTUP_SHA256=49c96f3f74be82f4752b8bffcf81961dea5e6e94ce1ccba94435f12e871c3bdb \
     RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
@@ -40,7 +40,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.41.0
+ENV RUST_VERSION=1.45.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \


### PR DESCRIPTION
Next: require tagging `rust-1.45.0` after merge this PR.