### PR TITLE
chore: bump rust toolchain from 1.45.0 to 1.45.2

### DIFF
--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -26,7 +26,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.45.0
+ENV RUST_VERSION=1.45.2
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.45.0
+ENV RUST_VERSION=1.45.2
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/gen-dockerfiles
+++ b/gen-dockerfiles
@@ -3,7 +3,7 @@
 import os
 from urllib import request
 
-RUST_VERSION = '1.45.0'
+RUST_VERSION = '1.45.2'
 RUSTUP_VERSION = '1.22.1'
 
 RUST_ARCH = 'x86_64-unknown-linux-gnu'

--- a/xenial/Dockerfile
+++ b/xenial/Dockerfile
@@ -40,7 +40,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.45.0
+ENV RUST_VERSION=1.45.2
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \


### PR DESCRIPTION
Next: require tagging `rust-1.45.2` after merge this PR.