### PR TITLE
Fix CI Docker test failure due to missing OpenSSL; Use `OPENSSL_STATIC=1` for building ckb in the CI environment

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -76,7 +76,7 @@ jobs:
 
     - name: Build CKB
       run: |
-        docker run --platform ${{matrix.platform}} --rm -i -w /ckb -v $(pwd)/ckb:/ckb ghcr.io/nervosnetwork/ckb-docker-builder:${{ matrix.distro }}-${{ github.sha }} make prod
+        docker run --platform ${{matrix.platform}} --rm -i -w /ckb -v $(pwd)/ckb:/ckb  -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include ghcr.io/nervosnetwork/ckb-docker-builder:${{ matrix.distro }}-${{ github.sha }} make prod
 
   publish:
     name: Publish


### PR DESCRIPTION
This PR want to fix [this](https://github.com/nervosnetwork/ckb-docker-builder/actions/runs/7176444514/job/19542669772)

@doitian 