### PR TITLE
Remove `OpenSSL` related build instructions, Upgrade `rust-toolchain` to `1.75.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
 DOCKERHUB_REPO := nervos/ckb-docker-builder
 GHCR_REPO := ghcr.io/nervosnetwork/ckb-docker-builder
 RUST_VERSION := rust-$(shell sed -n "s/RUST_VERSION\s*=\s*'\(.*\)'$$/\1/p" gen-dockerfiles)
-OPENSSL_VERSION := openssl-$(shell sed -n "s/OPENSSL_VERSION\s*=\s*'\(.*\)'$$/\1/p" gen-dockerfiles)
-IMAGE_VERSION := ${RUST_VERSION}-${OPENSSL_VERSION}
+IMAGE_VERSION := ${RUST_VERSION}
 
 bionic/Dockerfile: gen-dockerfiles templates/bionic.Dockerfile
 	python3 gen-dockerfiles
@@ -44,13 +43,9 @@ sync-ckb:
 	if [ -d ckb ]; then git -C ckb pull; else git clone --depth 1 https://github.com/nervosnetwork/ckb.git; fi
 
 test-bionic: sync-ckb
-	docker run --rm -it -w /ckb -v "$$(pwd)/ckb:/ckb" \
--e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include \
-${DOCKERHUB_REPO}:bionic-${IMAGE_VERSION} make prod
+	docker run --rm -it -w /ckb -v "$$(pwd)/ckb:/ckb" ${DOCKERHUB_REPO}:bionic-${IMAGE_VERSION} make prod
 
 test-centos-7: sync-ckb
-	docker run --rm -it -w /ckb -v "$$(pwd)/ckb:/ckb" \
--e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib64 -e OPENSSL_INCLUDE_DIR=/usr/local/include \
-${DOCKERHUB_REPO}:centos-7-${IMAGE_VERSION} make prod
+	docker run --rm -it -w /ckb -v "$$(pwd)/ckb:/ckb" ${DOCKERHUB_REPO}:centos-7-${IMAGE_VERSION} make prod
 
 .PHONY: test-all test-bionic test-centos-7 sync-ckb

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ Environment for building [ckb](https://github.com/nervosnetwork/ckb#readme).
 - Update rustup and openssl version if needed in [`gen-dockerfiles`].
 - Update rust version in [`gen-dockerfiles`].
 - Run the script [`gen-dockerfiles`].
-- Commit, tag `rust-${RUST_VERSION}` such as `rust-1.71.0-openssl-3.1.3`.
+- Commit, tag `rust-${RUST_VERSION}` such as `rust-1.75.0`.
 
 [`gen-dockerfiles`]: gen-dockerfiles

--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -20,22 +20,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=1.26.0 \
     RUSTUP_SHA256=673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800 \
-    RUST_ARCH=aarch64-unknown-linux-gnu \
-    OPENSSL_VERSION=3.1.3 \
-    OPENSSL_SHA256=f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6
-
-RUN set -eux; \
-    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
-    wget --no-check-certificate "$url"; \
-    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
-    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
-    cd openssl-${OPENSSL_VERSION}; \
-    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
+    RUST_ARCH=aarch64-unknown-linux-gnu
 
 RUN set -eux; \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
@@ -51,7 +36,6 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    openssl version;
+    rustc --version;
 
 RUN git config --global --add safe.directory /ckb

--- a/aarch64/Dockerfile
+++ b/aarch64/Dockerfile
@@ -28,7 +28,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.71.1
+ENV RUST_VERSION=1.75.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -27,7 +27,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.71.1
+ENV RUST_VERSION=1.75.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/bionic/Dockerfile
+++ b/bionic/Dockerfile
@@ -19,22 +19,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=1.26.0 \
     RUSTUP_SHA256=0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db \
-    RUST_ARCH=x86_64-unknown-linux-gnu \
-    OPENSSL_VERSION=3.1.3 \
-    OPENSSL_SHA256=f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6
-
-RUN set -eux; \
-    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
-    wget --no-check-certificate "$url"; \
-    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
-    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
-    cd openssl-${OPENSSL_VERSION}; \
-    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
+    RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
@@ -50,7 +35,6 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    openssl version;
+    rustc --version;
 
 RUN git config --global --add safe.directory /ckb

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -13,22 +13,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=1.26.0 \
     RUSTUP_SHA256=0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db \
-    RUST_ARCH=x86_64-unknown-linux-gnu \
-    OPENSSL_VERSION=3.1.3 \
-    OPENSSL_SHA256=f0316a2ebd89e7f2352976445458689f80302093788c466692fb2a188b2eacf6
-
-RUN set -eux; \
-    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
-    wget --no-check-certificate "$url"; \
-    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
-    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
-    cd openssl-${OPENSSL_VERSION}; \
-    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
+    RUST_ARCH=x86_64-unknown-linux-gnu
 
 RUN set -eux; \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
@@ -44,8 +29,7 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    openssl version;
+    rustc --version;
 
 RUN git config --global --add safe.directory /ckb
 

--- a/centos-7/Dockerfile
+++ b/centos-7/Dockerfile
@@ -21,7 +21,7 @@ RUN set -eux; \
     echo "${RUSTUP_SHA256} *rustup-init" | sha256sum -c -; \
     chmod +x rustup-init
 
-ENV RUST_VERSION=1.71.1
+ENV RUST_VERSION=1.75.0
 
 RUN set -eux; \
     ./rustup-init -y --no-modify-path --default-toolchain $RUST_VERSION; \

--- a/centos-7/entrypoint.sh
+++ b/centos-7/entrypoint.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-export OPENSSL_LIB_DIR=/usr/local/lib64 OPENSSL_INCLUDE_DIR=/usr/local/include
-
 scl enable devtoolset-8 llvm-toolset-7 "$*"

--- a/gen-dockerfiles
+++ b/gen-dockerfiles
@@ -5,7 +5,6 @@ from urllib import request
 
 RUST_VERSION     =  '1.71.1'
 RUSTUP_VERSION   =  '1.26.0'
-OPENSSL_VERSION  =  '3.1.3'
 
 DISTRIBUTIONS = {
     # Ubuntu
@@ -22,10 +21,6 @@ def fetch_rustup_hash(RUST_ARCH):
     with request.urlopen(url) as f:
         return f.read().decode('utf-8').split()[0]
 
-def fetch_openssl_hash():
-    url = f'https://www.openssl.org/source/openssl-{OPENSSL_VERSION}.tar.gz.sha256'
-    with request.urlopen(url) as f:
-        return f.read().decode('utf-8').split()[0]
 
 def load_template(dist):
     with open(f'templates/{dist}.Dockerfile', 'r') as f:
@@ -39,23 +34,20 @@ def save_dockerfile(dist, contents):
     with open(filepath, 'w') as f:
         f.write(contents)
 
-def generate_dockerfile(dist, rustup_sha256, openssl_sha256, RUST_ARCH):
+def generate_dockerfile(dist, rustup_sha256, RUST_ARCH):
     template = load_template(dist)
     rendered = template \
         .replace('%%RUST_VERSION%%', RUST_VERSION) \
         .replace('%%RUSTUP_VERSION%%', RUSTUP_VERSION) \
         .replace('%%RUSTUP_SHA256%%', rustup_sha256) \
-        .replace('%%RUST_ARCH%%', RUST_ARCH)  \
-        .replace('%%OPENSSL_VERSION%%', OPENSSL_VERSION) \
-        .replace('%%OPENSSL_SHA256%%', openssl_sha256)
+        .replace('%%RUST_ARCH%%', RUST_ARCH)
     save_dockerfile(dist, rendered)
 
 
 def main():
-    openssl_sha256 = fetch_openssl_hash()
     for dist, arch in DISTRIBUTIONS.items():
         rustup_sha256 = fetch_rustup_hash(arch)
-        generate_dockerfile(dist, rustup_sha256, openssl_sha256, arch)
+        generate_dockerfile(dist, rustup_sha256, arch)
 
 
 if __name__ == '__main__':

--- a/gen-dockerfiles
+++ b/gen-dockerfiles
@@ -3,7 +3,7 @@
 import os
 from urllib import request
 
-RUST_VERSION     =  '1.71.1'
+RUST_VERSION     =  '1.75.0'
 RUSTUP_VERSION   =  '1.26.0'
 
 DISTRIBUTIONS = {

--- a/templates/aarch64.Dockerfile
+++ b/templates/aarch64.Dockerfile
@@ -20,22 +20,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=%%RUSTUP_VERSION%% \
     RUSTUP_SHA256=%%RUSTUP_SHA256%% \
-    RUST_ARCH=%%RUST_ARCH%% \
-    OPENSSL_VERSION=%%OPENSSL_VERSION%% \
-    OPENSSL_SHA256=%%OPENSSL_SHA256%%
-
-RUN set -eux; \
-    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
-    wget --no-check-certificate "$url"; \
-    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
-    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
-    cd openssl-${OPENSSL_VERSION}; \
-    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
+    RUST_ARCH=%%RUST_ARCH%%
 
 RUN set -eux; \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
@@ -51,7 +36,6 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    openssl version;
+    rustc --version;
 
 RUN git config --global --add safe.directory /ckb

--- a/templates/bionic.Dockerfile
+++ b/templates/bionic.Dockerfile
@@ -19,22 +19,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=%%RUSTUP_VERSION%% \
     RUSTUP_SHA256=%%RUSTUP_SHA256%% \
-    RUST_ARCH=%%RUST_ARCH%% \
-    OPENSSL_VERSION=%%OPENSSL_VERSION%% \
-    OPENSSL_SHA256=%%OPENSSL_SHA256%%
-
-RUN set -eux; \
-    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
-    wget --no-check-certificate "$url"; \
-    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
-    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
-    cd openssl-${OPENSSL_VERSION}; \
-    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
+    RUST_ARCH=%%RUST_ARCH%%
 
 RUN set -eux; \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
@@ -50,7 +35,6 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    openssl version;
+    rustc --version;
 
 RUN git config --global --add safe.directory /ckb

--- a/templates/centos-7.Dockerfile
+++ b/templates/centos-7.Dockerfile
@@ -13,22 +13,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
     PATH=/usr/local/cargo/bin:$PATH \
     RUSTUP_VERSION=%%RUSTUP_VERSION%% \
     RUSTUP_SHA256=%%RUSTUP_SHA256%% \
-    RUST_ARCH=%%RUST_ARCH%% \
-    OPENSSL_VERSION=%%OPENSSL_VERSION%% \
-    OPENSSL_SHA256=%%OPENSSL_SHA256%%
-
-RUN set -eux; \
-    url="https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"; \
-    wget --no-check-certificate "$url"; \
-    echo "${OPENSSL_SHA256} *openssl-${OPENSSL_VERSION}.tar.gz" | sha256sum -c -; \
-    tar -xzf "openssl-${OPENSSL_VERSION}.tar.gz"; \
-    cd openssl-${OPENSSL_VERSION}; \
-    ./config no-shared no-zlib -fPIC -DOPENSSL_NO_SECURE_MEMORY; \
-    make; \
-    make install; \
-    cd ..; \
-    rm -rf openssl-${OPENSSL_VERSION} openssl-${OPENSSL_VERSION}.tar.gz
-
+    RUST_ARCH=%%RUST_ARCH%%
 
 RUN set -eux; \
     url="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUST_ARCH}/rustup-init"; \
@@ -44,8 +29,7 @@ RUN set -eux; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \
     cargo --version; \
-    rustc --version; \
-    openssl version;
+    rustc --version;
 
 RUN git config --global --add safe.directory /ckb
 


### PR DESCRIPTION
1. I've removed the OpenSSL-related build instructions as CKB can now statically link OpenSSL by "enabling the openssl-vendored feature in tentacle". See the related pull request here: https://github.com/nervosnetwork/ckb/pull/4320
2. It's time we updated our rust-toolchain. It's been five months since our last update.
